### PR TITLE
Disconnecting from the IRC channel is not normal

### DIFF
--- a/lib/bot.ex
+++ b/lib/bot.ex
@@ -73,7 +73,7 @@ defmodule Boringbot.Bot do
   end
   def handle_info(:disconnected, config) do
     Logger.debug "Disconnected from #{config.server}:#{config.port}"
-    {:stop, :normal, config}
+    {:stop, :disconnected, config}
   end
   def handle_info({:joined, channel}, config) do
     Logger.debug "Joined #{channel}"

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Boringbot.Mixfile do
 
   def project do
     [app: :boringbot,
-     version: "0.3.0",
+     version: "0.3.1",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
This should end the occasional "bors is disconnected and just sitting there running" problem.